### PR TITLE
fix: updated phpDoc parameter type

### DIFF
--- a/src/byteShard/Action/CallMethod.php
+++ b/src/byteShard/Action/CallMethod.php
@@ -42,7 +42,7 @@ class CallMethod extends Action
     /**
      * CallMethod constructor.
      * @param string $methodName
-     * @param null $methodParameter
+     * @param mixed $methodParameter
      */
     public function __construct(string $methodName, mixed $methodParameter = null)
     {


### PR DESCRIPTION
In PhpDoc parameter datatype updated as already declared in constructor mixed as datatype.